### PR TITLE
Update readme and fix bookmark bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This tap:
 
     ```json
     {
-      "circle_ci_token": "your-access-token",
+      "token": "your-access-token",
       "project_slugs": "gh/singer-io/singer-python gh/singer-io/getting-started"
     }
     ```
@@ -87,12 +87,12 @@ This tap:
     `tap-circle-ci` can be run with:
 
     ```bash
-    tap-github --config config.json --catalog catalog.json
+    tap-circle-ci --config config.json --catalog catalog.json
     ```
 
     To save output to a file:
     ```bash
-    tap-github --config config.json --catalog catalog.json > output.txt
+    tap-circle-ci --config config.json --catalog catalog.json > output.txt
     ```
     It is our intention that this singer tap gets used with a singer target, which will load the output into a database.
     More information on singer targets [here](https://github.com/singer-io/getting-started/blob/master/docs/RUNNING_AND_DEVELOPING.md#running-a-singer-tap-with-a-singer-target).


### PR DESCRIPTION
# Description of change

This fixes a pretty gnarly bug, which was preventing any new rows from being synced. Previously, the behavior was as follows: 

1) All historical data syncs on March 15th, and the bookmark for pipelines is written to state as March 15th
2) A sync starts on March 16th - it skips all pipelines that aren't at least 1 week old, and tries to sync pipelines that begin on March 9th. March 9th is older than the March 15th bookmark, so it breaks without extracting any pipelines and writes March 16th to state. 
3) This behavior repeats with each attempted sync

With this change, the extraction time minus the seven day buffer is written to state as the bookmark, which should allow pipelines at least seven days old to get extracted.

# Manual QA steps

Set a sample state as the current day, and run an extraction. Ensure no records are produced and the state gets overwritten as the current day minus 7 days. Subtract 1 day from the state (it should now be current day minus 8 days) and re-run the extraction. Ensure that records are loaded with dates ranging from the current day minus 8 days to the current day minus seven days.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
